### PR TITLE
Remove test imports for django test runner

### DIFF
--- a/crispy_forms/tests/__init__.py
+++ b/crispy_forms/tests/__init__.py
@@ -1,5 +1,0 @@
-from .test_tags import *
-from .test_layout import *
-from .test_layout_objects import *
-from .test_form_helper import *
-from .test_dynamic_api import *


### PR DESCRIPTION
Hmm, looks like this may break the local travis tests. Not sure of the best solution. Maybe exclude `submodules/bootstrap3_crispy` when running HQ tests?

@nickpell cc @proteusvacuum 
